### PR TITLE
fix: Update links to 2018 and 2020 data cleaning notebooks

### DIFF
--- a/Datacleaning/Compile 2018 AQI Data.ipynb
+++ b/Datacleaning/Compile 2018 AQI Data.ipynb
@@ -150,8 +150,8 @@
     "#note that there are probably ~2 million rows to in the final table, so the operations might take a few seconds\n",
     "\n",
     "#read in the different quarters - two are shown here\n",
-    "AQI_Info_Q1_2019 = pd.read_csv(\"./Resources/2019 csvs/waqi-covid19-airqualitydata-2019Q1.csv\")\n",
-    "AQI_Info_Q2_2019 = pd.read_csv(\"./Resources/2019 csvs/waqi-covid19-airqualitydata-2019Q2.csv\")\n",
+    "AQI_Info_Q1_2019 = pd.read_csv(\"./2019 Source/waqi-covid19-airqualitydata-2019Q1.csv\")\n",
+    "AQI_Info_Q2_2019 = pd.read_csv(\"./2019 Source/waqi-covid19-airqualitydata-2019Q2.csv\")\n",
     "\n",
     "#add the quarters together using pandas' merge operation - outer join\n",
     "all_quarters_df = AQI_Info_Q1_2019.merge(AQI_Info_Q2_2019, how=\"outer\")\n",
@@ -460,8 +460,8 @@
    "source": [
     "#import csv info for conversion table between AQI and pollutant concentrations\n",
     "\n",
-    "pm25_conversion_df = pd.read_csv(\"./Resources/Conversion CSVs/pm25_conversion.csv\")\n",
-    "o3_conversion_df = pd.read_csv(\"./Resources/Conversion CSVs/o3_conversion.csv\")"
+    "pm25_conversion_df = pd.read_csv(\"../Resources/pm25_conversion.csv\")\n",
+    "o3_conversion_df = pd.read_csv(\"../Resources/o3_conversion.csv\")"
    ]
   },
   {
@@ -648,10 +648,10 @@
    "outputs": [],
    "source": [
     "#output the pm25 concentration data for our cities for the year 2018\n",
-    "interesting_cities_pm25_2018_conc.to_csv(\"./Resources/2018 Cleaned/our_cities_pm25_2018.csv\", index=False)\n",
+    "interesting_cities_pm25_2018_conc.to_csv(\"./2018 Cleaned/our_cities_pm25_2018.csv\", index=False)\n",
     "\n",
     "#output the o3 concentration data for our cities for the year 2018\n",
-    "interesting_cities_o3_2018_conc.to_csv(\"./Resources/2018 Cleaned/our_cities_o3_2018.csv\", index=False)"
+    "interesting_cities_o3_2018_conc.to_csv(\"./2018 Cleaned/our_cities_o3_2018.csv\", index=False)"
    ]
   },
   {

--- a/Datacleaning/Compile 2020 AQI Data.ipynb
+++ b/Datacleaning/Compile 2020 AQI Data.ipynb
@@ -157,8 +157,8 @@
     "#note that there are probably ~2 million rows to in the final table, so the operations might take a few seconds\n",
     "\n",
     "#read in the different quarters - two are shown here\n",
-    "AQI_Info_Q1_2019 = pd.read_csv(\"./Resources/2019 csvs/waqi-covid19-airqualitydata-2019Q1.csv\")\n",
-    "AQI_Info_Q2_2019 = pd.read_csv(\"./Resources/2019 csvs/waqi-covid19-airqualitydata-2019Q2.csv\")\n",
+    "AQI_Info_Q1_2019 = pd.read_csv(\"./2019 Source/waqi-covid19-airqualitydata-2019Q1.csv\")\n",
+    "AQI_Info_Q2_2019 = pd.read_csv(\"./2019 Source/waqi-covid19-airqualitydata-2019Q2.csv\")\n",
     "\n",
     "#add the quarters together using pandas' merge operation - outer join\n",
     "all_quarters_df = AQI_Info_Q1_2019.merge(AQI_Info_Q2_2019, how=\"outer\")\n",
@@ -467,8 +467,8 @@
    "source": [
     "#import csv info for conversion table between AQI and pollutant concentrations\n",
     "\n",
-    "pm25_conversion_df = pd.read_csv(\"./Resources/Conversion CSVs/pm25_conversion.csv\")\n",
-    "o3_conversion_df = pd.read_csv(\"./Resources/Conversion CSVs/o3_conversion.csv\")"
+    "pm25_conversion_df = pd.read_csv(\"../Resources/pm25_conversion.csv\")\n",
+    "o3_conversion_df = pd.read_csv(\"../Resources/o3_conversion.csv\")"
    ]
   },
   {
@@ -655,10 +655,10 @@
    "outputs": [],
    "source": [
     "#output the pm25 concentration data for our cities for the year 2018\n",
-    "interesting_cities_pm25_2020_conc.to_csv(\"./Resources/2020 Data Cleaned/our_cities_pm25_2020.csv\", index=False)\n",
+    "interesting_cities_pm25_2020_conc.to_csv(\"./2020 Cleaned/our_cities_pm25_2020.csv\", index=False)\n",
     "\n",
     "#output the o3 concentration data for our cities for the year 2018\n",
-    "interesting_cities_o3_2020_conc.to_csv(\"./Resources/2020 Data Cleaned/our_cities_o3_2020.csv\", index=False)"
+    "interesting_cities_o3_2020_conc.to_csv(\"./2020 Cleaned/our_cities_o3_2020.csv\", index=False)"
    ]
   },
   {


### PR DESCRIPTION
This should update the links for my datacleaning notebooks for 2018 and 2020